### PR TITLE
Backend Trait

### DIFF
--- a/src/backend/local.rs
+++ b/src/backend/local.rs
@@ -2,6 +2,7 @@ use super::Backend;
 use std::fs::{self, File};
 use std::io;
 use std::path::{Path, PathBuf};
+use std::slice;
 
 
 /// Backend operating on the local filesystem.
@@ -28,12 +29,13 @@ impl LocalBackend {
     }
 }
 
-impl Backend for LocalBackend {
-    type FileName = PathBuf;
+impl<'a> Backend<'a> for LocalBackend {
+    type FileName = &'a PathBuf;
+    type FileNameIter = slice::Iter<'a, PathBuf>;
     type FileStream = File;
 
-    fn get_file_names(&self) -> io::Result<&[PathBuf]> {
-        Ok(&self.file_names)
+    fn get_file_names(&'a self) -> io::Result<Self::FileNameIter> {
+        Ok(self.file_names.iter())
     }
 
     fn open_file(&self, name: &Path) -> io::Result<File> {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -5,17 +5,20 @@ use std::path::Path;
 
 
 /// Backend is a trait used to provide access to backup files.
-pub trait Backend {
+pub trait Backend<'a> {
     /// FileName is an associated type for a file name. It must be convertible to a string
     /// reference.
     type FileName: AsRef<Path>;
+
+    /// FileNameIter is an associated type for an iterator over filenames.
+    type FileNameIter: Iterator<Item=Self::FileName>;
 
     /// FileStream is an associated type for a read stream for a file.
     type FileStream: Read;
 
     /// Returns a list of available file names.
     /// The file names returned should have an extension, and not a path.
-    fn get_file_names(&self) -> io::Result<&[Self::FileName]>;
+    fn get_file_names(&'a self) -> io::Result<Self::FileNameIter>;
 
     /// Open a file for reading.
     fn open_file(&self, name: &Path) -> io::Result<Self::FileStream>;

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -5,20 +5,17 @@ use std::path::Path;
 
 
 /// Backend is a trait used to provide access to backup files.
-pub trait Backend<'a> {
+pub trait Backend {
     /// FileName is an associated type for a file name. It must be convertible to a string
     /// reference.
     type FileName: AsRef<Path>;
-
-    /// FileNameIter is an associated type for an iterator over filenames.
-    type FileNameIter: Iterator<Item=Self::FileName>;
 
     /// FileStream is an associated type for a read stream for a file.
     type FileStream: Read;
 
     /// Returns a list of available file names.
     /// The file names returned should have an extension, and not a path.
-    fn get_file_names(&'a self) -> io::Result<Self::FileNameIter>;
+    fn get_file_names(&self) -> io::Result<Vec<Self::FileName>>;
 
     /// Open a file for reading.
     fn open_file(&self, name: &Path) -> io::Result<Self::FileStream>;

--- a/src/collections/mod.rs
+++ b/src/collections/mod.rs
@@ -358,8 +358,7 @@ impl CollectionsStatus {
         }
     }
 
-    pub fn from_filenames<P: AsRef<Path>>(filenames: &[P]) -> Self
-    {
+    pub fn from_filenames<P: AsRef<Path>>(filenames: &[P]) -> Self {
         let infos = compute_filename_infos(filenames);
         CollectionsStatus {
             backup_chains: compute_backup_chains(&infos),

--- a/src/collections/mod.rs
+++ b/src/collections/mod.rs
@@ -358,22 +358,9 @@ impl CollectionsStatus {
         }
     }
 
-    pub fn from_filenames<'a, I, E>(filenames: I) -> Self
-        where I: IntoIterator<Item = &'a E>,
-              E: AsRef<Path> + 'a
+    pub fn from_filenames<P: AsRef<Path>>(filenames: &[P]) -> Self
     {
-        let infos = {
-            let mut infos = Vec::new();
-            let parser = FileNameParser::new();
-            for name in filenames {
-                if let Some(name) = name.as_ref().to_str() {
-                    if let Some(info) = parser.parse(name) {
-                        infos.push(FileNameInfo::new(name, info));
-                    }
-                }
-            }
-            infos
-        };
+        let infos = compute_filename_infos(filenames);
         CollectionsStatus {
             backup_chains: compute_backup_chains(&infos),
             sig_chains: compute_signature_chains(&infos),

--- a/src/collections/mod.rs
+++ b/src/collections/mod.rs
@@ -358,8 +358,11 @@ impl CollectionsStatus {
         }
     }
 
-    pub fn from_filenames<T: AsRef<Path>>(filenames: &[T]) -> Self {
-        let infos = compute_filename_infos(&filenames);
+    pub fn from_filenames<I, E>(filenames: I) -> Self
+        where I: Iterator<Item = E>,
+              E: AsRef<Path>
+    {
+        let infos = compute_filename_infos(filenames);
         CollectionsStatus {
             backup_chains: compute_backup_chains(&infos),
             sig_chains: compute_signature_chains(&infos),
@@ -376,7 +379,10 @@ impl CollectionsStatus {
 
 }
 
-fn compute_filename_infos<T: AsRef<Path>>(filenames: &[T]) -> Vec<FileNameInfo> {
+fn compute_filename_infos<'a, I, E>(filenames: I) -> Vec<FileNameInfo<'a>>
+    where I: Iterator<Item = E>,
+          E: AsRef<Path> + 'a
+{
     let mut result = Vec::new();
     let parser = FileNameParser::new();
     for name in filenames {

--- a/src/signatures.rs
+++ b/src/signatures.rs
@@ -97,10 +97,10 @@ struct UserGroupNameCache {
 
 
 impl BackupFiles {
-    pub fn new<'a, B: Backend<'a>>(backend: &'a B) -> io::Result<BackupFiles> {
+    pub fn new<B: Backend>(backend: &B) -> io::Result<BackupFiles> {
         let collection = {
             let filenames = try!(backend.get_file_names());
-            CollectionsStatus::from_filenames(filenames)
+            CollectionsStatus::from_filenames(&filenames)
         };
         let mut chains: Vec<Chain> = Vec::new();
         let mut ug_cache = UserGroupNameCache::new();

--- a/src/signatures.rs
+++ b/src/signatures.rs
@@ -97,10 +97,10 @@ struct UserGroupNameCache {
 
 
 impl BackupFiles {
-    pub fn new<B: Backend>(backend: &B) -> io::Result<BackupFiles> {
+    pub fn new<'a, B: Backend<'a>>(backend: &'a B) -> io::Result<BackupFiles> {
         let collection = {
             let filenames = try!(backend.get_file_names());
-            CollectionsStatus::from_filenames(&filenames)
+            CollectionsStatus::from_filenames(filenames)
         };
         let mut chains: Vec<Chain> = Vec::new();
         let mut ug_cache = UserGroupNameCache::new();


### PR DESCRIPTION
Fixes #21.

We do not use an `Iterator`, but now the ownership of file names returned by `Backend` trait is more clear.