### PR TITLE
Backend trait refactor

### DIFF
--- a/src/backend/local.rs
+++ b/src/backend/local.rs
@@ -11,8 +11,8 @@ pub struct LocalBackend {
 
 impl LocalBackend {
     /// Create a new LocalBackend that operates on the given directory.
-    pub fn new<P: AsRef<Path>>(path: P) -> io::Result<Self> {
-        Ok(LocalBackend { base_path: path.as_ref().to_path_buf() })
+    pub fn new<P: AsRef<Path>>(path: P) -> Self {
+        LocalBackend { base_path: path.as_ref().to_path_buf() }
     }
 }
 

--- a/src/backend/local.rs
+++ b/src/backend/local.rs
@@ -18,9 +18,10 @@ impl LocalBackend {
 
 impl Backend for LocalBackend {
     type FileName = PathBuf;
+    type FileNameIter = Vec<PathBuf>;
     type FileStream = File;
 
-    fn get_file_names(&self) -> io::Result<Vec<Self::FileName>> {
+    fn get_file_names(&self) -> io::Result<Self::FileNameIter> {
         let dir = try!(fs::read_dir(self.base_path.as_path()));
         let paths = dir.filter(|entry| entry.is_ok())
                        .map(|entry| {

--- a/src/backend/local.rs
+++ b/src/backend/local.rs
@@ -42,7 +42,7 @@ impl Iterator for FileNameIterator {
     type Item = OsString;
 
     fn next(&mut self) -> Option<OsString> {
-        while let Some(entry) = self.0.next() {
+        for entry in &mut self.0 {
             if let Ok(entry) = entry {
                 return Some(entry.file_name());
             }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -10,12 +10,15 @@ pub trait Backend {
     /// reference.
     type FileName: AsRef<Path>;
 
+    /// FileNameIter is an associated type for an iterator over filenames.
+    type FileNameIter: IntoIterator<Item=Self::FileName>;
+
     /// FileStream is an associated type for a read stream for a file.
     type FileStream: Read;
 
     /// Returns a list of available file names.
-    /// The file names returned should have an extension, and not a path.
-    fn get_file_names(&self) -> io::Result<Vec<Self::FileName>>;
+    /// The file names returned should have an extension, and do not contain the base path.
+    fn get_file_names(&self) -> io::Result<Self::FileNameIter>;
 
     /// Open a file for reading.
     fn open_file(&self, name: &Path) -> io::Result<Self::FileStream>;

--- a/src/collections/mod.rs
+++ b/src/collections/mod.rs
@@ -358,8 +358,12 @@ impl CollectionsStatus {
         }
     }
 
-    pub fn from_filenames<P: AsRef<Path>>(filenames: &[P]) -> Self {
-        let infos = compute_filename_infos(filenames);
+    pub fn from_filenames<I>(filenames: I) -> Self
+        where I: IntoIterator,
+              I::Item: AsRef<Path>
+    {
+        let fnames_vec: Vec<_> = filenames.into_iter().collect();
+        let infos = compute_filename_infos(&fnames_vec);
         CollectionsStatus {
             backup_chains: compute_backup_chains(&infos),
             sig_chains: compute_signature_chains(&infos),

--- a/src/signatures.rs
+++ b/src/signatures.rs
@@ -100,7 +100,7 @@ impl BackupFiles {
     pub fn new<B: Backend>(backend: &B) -> io::Result<BackupFiles> {
         let collection = {
             let filenames = try!(backend.get_file_names());
-            CollectionsStatus::from_filenames(&filenames)
+            CollectionsStatus::from_filenames(filenames)
         };
         let mut chains: Vec<Chain> = Vec::new();
         let mut ug_cache = UserGroupNameCache::new();

--- a/src/signatures.rs
+++ b/src/signatures.rs
@@ -613,7 +613,7 @@ mod test {
     #[test]
     fn file_list() {
         let expected_files = get_single_vol_files();
-        let backend = LocalBackend::new("tests/backups/single_vol").unwrap();
+        let backend = LocalBackend::new("tests/backups/single_vol");
         let files = BackupFiles::new(&backend).unwrap();
         // println!("debug files\n---------\n{:#?}\n----------", files);
         let actual_files = files.snapshots().map(|s| {
@@ -631,7 +631,7 @@ mod test {
 
     #[test]
     fn size_hint() {
-        let backend = LocalBackend::new("tests/backups/single_vol").unwrap();
+        let backend = LocalBackend::new("tests/backups/single_vol");
         let files = BackupFiles::new(&backend).unwrap();
         let actual_sizes = files.snapshots().map(|s| {
             s.files()
@@ -660,7 +660,7 @@ mod test {
         // avoid test differences for time zones
         let _lock = set_time_zone("Europe/Rome");
 
-        let backend = LocalBackend::new("tests/backups/single_vol").unwrap();
+        let backend = LocalBackend::new("tests/backups/single_vol");
         let files = BackupFiles::new(&backend).unwrap();
         println!("Backup snapshots:");
         for snapshot in files.snapshots() {


### PR DESCRIPTION
Another refactor for `Backend` trait. This allows to lazy build the file name list. Refactored local backend to use this feature.