### PR TITLE
Collections iface

### DIFF
--- a/src/bin/ruplicity-console.rs
+++ b/src/bin/ruplicity-console.rs
@@ -7,7 +7,7 @@ use std::process;
 
 use ruplicity::backend::Backend;
 use ruplicity::backend::local::LocalBackend;
-use ruplicity::collections::CollectionsStatus;
+use ruplicity::collections::Collections;
 use ruplicity::signatures::BackupFiles;
 
 
@@ -31,7 +31,7 @@ fn main() {
         // calling unwrap is safe here, because INPUT is required
         let path = matches.value_of("INPUT").unwrap();
         let backend = LocalBackend::new(path);
-        let collection = CollectionsStatus::from_filenames(ordie(backend.get_file_names()));
+        let collection = Collections::from_filenames(ordie(backend.get_file_names()));
         println!("{}", collection);
     } else if let Some(matches) = matches.subcommand_matches("ls") {
         // calling unwrap is safe here, because INPUT is required

--- a/src/collections/mod.rs
+++ b/src/collections/mod.rs
@@ -205,11 +205,11 @@ impl BackupSet {
     }
 
     pub fn is_full(&self) -> bool {
-        matches!(&self.tp, &Type::Full{..})
+        matches!(self.tp, Type::Full{..})
     }
 
     pub fn is_incremental(&self) -> bool {
-        matches!(&self.tp, &Type::Inc{..})
+        matches!(self.tp, Type::Inc{..})
     }
 
     fn fix_encrypted(&mut self, pr_encrypted: bool) {

--- a/src/collections/mod.rs
+++ b/src/collections/mod.rs
@@ -643,13 +643,15 @@ mod test {
         {
             let inc = &backup_chain.incsets[0];
             assert!(inc.is_incremental());
-            assert_eq!(inc.start_time(), parse_time_str("20150617t182545z").unwrap());
+            assert_eq!(inc.start_time(),
+                       parse_time_str("20150617t182545z").unwrap());
             assert_eq!(inc.end_time(), parse_time_str("20150617t182629z").unwrap());
         }
         {
             let inc = &backup_chain.incsets[1];
             assert!(inc.is_incremental());
-            assert_eq!(inc.start_time(), parse_time_str("20150617t182629z").unwrap());
+            assert_eq!(inc.start_time(),
+                       parse_time_str("20150617t182629z").unwrap());
             assert_eq!(inc.end_time(), parse_time_str("20150617t182650z").unwrap());
         }
     }

--- a/src/signatures.rs
+++ b/src/signatures.rs
@@ -10,7 +10,7 @@ use tar;
 use time::Timespec;
 
 use backend::Backend;
-use collections::{CollectionsStatus, SignatureFile};
+use collections::{Collections, SignatureFile};
 use time_utils::to_pretty_local;
 
 
@@ -108,7 +108,7 @@ impl BackupFiles {
     pub fn new<B: Backend>(backend: &B) -> io::Result<BackupFiles> {
         let collection = {
             let filenames = try!(backend.get_file_names());
-            CollectionsStatus::from_filenames(filenames)
+            Collections::from_filenames(filenames)
         };
         let mut chains: Vec<Chain> = Vec::new();
         let mut ug_map = UserGroupMap::new();

--- a/src/signatures.rs
+++ b/src/signatures.rs
@@ -121,10 +121,10 @@ impl BackupFiles {
             };
             // add to the chain the full signature and all the incremental signatures
             // if an error occurs in the full signature exit
-            let file = try!(backend.open_file(coll_chain.fullsig.file_name.as_ref()));
-            try!(add_sigfile_to_chain(&mut chain, &mut ug_map, file, &coll_chain.fullsig));
-            for inc in &coll_chain.inclist {
-                // TODO: if an error occurs here, do not exit with an error, instead
+            let file = try!(backend.open_file(coll_chain.full_signature().file_name.as_ref()));
+            try!(add_sigfile_to_chain(&mut chain, &mut ug_map, file, coll_chain.full_signature()));
+            for inc in coll_chain.inc_signatures() {
+                // TODO(#4): if an error occurs here, do not exit with an error, instead
                 // break the iteration and store the error inside the chain
                 let file = try!(backend.open_file(inc.file_name.as_ref()));
                 try!(add_sigfile_to_chain(&mut chain, &mut ug_map, file, &inc));


### PR DESCRIPTION
Chosen to cleanup `collections` mod interface and to delegate actual lazy work for a super module orchestrating `signatures` and `collections` mods.

Closes #3.